### PR TITLE
Add CrazyStorm MCP server

### DIFF
--- a/CrazyStorm.McpServer/CrazyStorm.McpServer.csproj
+++ b/CrazyStorm.McpServer/CrazyStorm.McpServer.csproj
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{914017D4-B5F4-45AA-BC74-FEA7FD754F34}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CrazyStorm.McpServer</RootNamespace>
+    <AssemblyName>CrazyStorm.McpServer</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CrazyStormTools.cs" />
+    <Compile Include="McpProtocol.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="README.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj">
+      <Project>{1FED6550-8156-45BA-ABD3-7C400FD86A03}</Project>
+      <Name>Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/CrazyStorm.McpServer/CrazyStormTools.cs
+++ b/CrazyStorm.McpServer/CrazyStormTools.cs
@@ -1,0 +1,379 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) StarX 2026
+ */
+using CrazyStorm.Core;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Web.Script.Serialization;
+using System.Xml;
+using CsFile = CrazyStorm.Core.File;
+using IoFile = System.IO.File;
+
+namespace CrazyStorm.McpServer
+{
+    internal sealed class CrazyStormTools
+    {
+        private readonly JavaScriptSerializer json = new JavaScriptSerializer();
+
+        public object[] ListTools()
+        {
+            return new object[]
+            {
+                Tool(
+                    "crazy_storm_project_summary",
+                    "Load a CrazyStorm .bgp/.mbg project and return counts for particle systems, layers, components, resources, and invalid resource references.",
+                    new Dictionary<string, object>
+                    {
+                        { "path", StringProperty("Project file path. Relative paths resolve from the MCP server working directory.") }
+                    },
+                    new[] { "path" }),
+
+                Tool(
+                    "crazy_storm_validate_project",
+                    "Validate that a CrazyStorm project can be loaded. Optionally compile it in memory to catch expression and event errors.",
+                    new Dictionary<string, object>
+                    {
+                        { "path", StringProperty("Project file path. Relative paths resolve from the MCP server working directory.") },
+                        { "compile", new Dictionary<string, object>
+                            {
+                                { "type", "boolean" },
+                                { "description", "When true, also generates play data in memory to compile expressions and events." },
+                                { "default", false }
+                            }
+                        }
+                    },
+                    new[] { "path" }),
+
+                Tool(
+                    "crazy_storm_export_play_data",
+                    "Load a CrazyStorm project and export playable .bg data.",
+                    new Dictionary<string, object>
+                    {
+                        { "path", StringProperty("Project file path. Relative paths resolve from the MCP server working directory.") },
+                        { "outputPath", StringProperty("Optional output .bg path. Defaults to the project file name with a .bg extension.") },
+                        { "overwrite", new Dictionary<string, object>
+                            {
+                                { "type", "boolean" },
+                                { "description", "Set true to overwrite an existing output file." },
+                                { "default", false }
+                            }
+                        }
+                    },
+                    new[] { "path" },
+                    new Dictionary<string, object>
+                    {
+                        { "destructiveHint", true },
+                        { "idempotentHint", false }
+                    }),
+
+                Tool(
+                    "crazy_storm_component_types",
+                    "List component types available in CrazyStorm.Core.",
+                    new Dictionary<string, object>(),
+                    new string[0])
+            };
+        }
+
+        public Dictionary<string, object> Call(string name, Dictionary<string, object> arguments)
+        {
+            try
+            {
+                switch (name)
+                {
+                    case "crazy_storm_project_summary":
+                        return TextResult(ToJson(BuildSummary(LoadProject(GetRequiredPath(arguments)))));
+
+                    case "crazy_storm_validate_project":
+                        return TextResult(ToJson(ValidateProject(arguments)));
+
+                    case "crazy_storm_export_play_data":
+                        return TextResult(ToJson(ExportPlayData(arguments)));
+
+                    case "crazy_storm_component_types":
+                        return TextResult(ToJson(GetComponentTypes()));
+
+                    default:
+                        return ErrorResult("Unknown tool: " + name);
+                }
+            }
+            catch (Exception ex)
+            {
+                return ErrorResult(ex.Message);
+            }
+        }
+
+        private Dictionary<string, object> ValidateProject(Dictionary<string, object> arguments)
+        {
+            string path = GetRequiredPath(arguments);
+            bool compile = McpProtocol.GetBool(arguments, "compile", false);
+
+            var loaded = LoadProject(path);
+            byte[] playBytes = null;
+            if (compile) playBytes = loaded.Project.GeneratePlayFile();
+
+            var summary = BuildSummary(loaded);
+            summary["valid"] = true;
+            summary["compiled"] = compile;
+            if (playBytes != null) summary["playDataBytes"] = playBytes.Length;
+            return summary;
+        }
+
+        private Dictionary<string, object> ExportPlayData(Dictionary<string, object> arguments)
+        {
+            string path = GetRequiredPath(arguments);
+            string outputPath = McpProtocol.GetString(arguments, "outputPath");
+            bool overwrite = McpProtocol.GetBool(arguments, "overwrite", false);
+
+            var loaded = LoadProject(path);
+            string resolvedOutputPath = ResolveOutputPath(loaded.Path, outputPath);
+            if (IoFile.Exists(resolvedOutputPath) && !overwrite)
+            {
+                throw new InvalidOperationException("Output already exists. Pass overwrite=true to replace it: " + resolvedOutputPath);
+            }
+
+            byte[] bytes = loaded.Project.GeneratePlayFile();
+            IoFile.WriteAllBytes(resolvedOutputPath, bytes);
+
+            return new Dictionary<string, object>
+            {
+                { "projectPath", loaded.Path },
+                { "outputPath", resolvedOutputPath },
+                { "bytes", bytes.Length },
+                { "overwritten", overwrite }
+            };
+        }
+
+        private LoadedProject LoadProject(string path)
+        {
+            string fullPath = ResolvePath(path);
+            if (!IoFile.Exists(fullPath)) throw new FileNotFoundException("Project file not found.", fullPath);
+
+            var project = new CsFile();
+            project.Load(fullPath);
+
+            return new LoadedProject
+            {
+                Path = fullPath,
+                Project = project,
+                Version = ReadProjectVersion(fullPath),
+                IsLegacyCs1 = CsFile.IsCS1(fullPath)
+            };
+        }
+
+        private Dictionary<string, object> BuildSummary(LoadedProject loaded)
+        {
+            var systems = new List<object>();
+            int layerCount = 0;
+            int componentCount = 0;
+            int noteCount = 0;
+            var componentTypes = new Dictionary<string, int>();
+
+            foreach (var system in loaded.Project.ParticleSystems)
+            {
+                int systemComponentCount = 0;
+                var layerSummaries = new List<object>();
+
+                foreach (var layer in system.Layers)
+                {
+                    layerCount++;
+                    componentCount += layer.Components.Count;
+                    systemComponentCount += layer.Components.Count;
+
+                    foreach (var component in layer.Components)
+                    {
+                        string typeName = component.GetType().Name;
+                        if (!componentTypes.ContainsKey(typeName)) componentTypes[typeName] = 0;
+                        componentTypes[typeName]++;
+                    }
+
+                    layerSummaries.Add(new Dictionary<string, object>
+                    {
+                        { "name", layer.Name },
+                        { "visible", layer.Visible },
+                        { "beginFrame", layer.BeginFrame },
+                        { "totalFrame", layer.TotalFrame },
+                        { "componentCount", layer.Components.Count }
+                    });
+                }
+
+                noteCount += system.Notes.Count;
+                systems.Add(new Dictionary<string, object>
+                {
+                    { "name", system.Name },
+                    { "totalFrame", system.TotalFrame },
+                    { "layerCount", system.Layers.Count },
+                    { "componentCount", systemComponentCount },
+                    { "customTypeCount", system.CustomTypes.Count },
+                    { "customDistortTypeCount", system.CustomDistortTypes.Count },
+                    { "customMaskTypeCount", system.CustomMaskTypes.Count },
+                    { "noteCount", system.Notes.Count },
+                    { "layers", layerSummaries.ToArray() }
+                });
+            }
+
+            var invalidResources = GetInvalidResources(loaded.Project);
+
+            return new Dictionary<string, object>
+            {
+                { "path", loaded.Path },
+                { "format", loaded.IsLegacyCs1 ? "Crazy Storm 1.x mbg" : "Crazy Storm 2 bgp" },
+                { "version", loaded.Version },
+                { "particleSystemCount", loaded.Project.ParticleSystems.Count },
+                { "layerCount", layerCount },
+                { "componentCount", componentCount },
+                { "noteCount", noteCount },
+                { "imageCount", loaded.Project.Images.Count },
+                { "soundCount", loaded.Project.Sounds.Count },
+                { "globalVariableCount", loaded.Project.Globals.Count },
+                { "invalidResourceCount", invalidResources.Count },
+                { "invalidResources", invalidResources.ToArray() },
+                { "componentTypes", componentTypes },
+                { "particleSystems", systems.ToArray() }
+            };
+        }
+
+        private List<object> GetInvalidResources(CsFile project)
+        {
+            var invalid = new List<object>();
+            AppendInvalidResources(invalid, "image", project.Images);
+            AppendInvalidResources(invalid, "sound", project.Sounds);
+            return invalid;
+        }
+
+        private void AppendInvalidResources(List<object> invalid, string kind, IEnumerable<FileResource> resources)
+        {
+            foreach (var resource in resources)
+            {
+                if (resource.IsValid) continue;
+                invalid.Add(new Dictionary<string, object>
+                {
+                    { "kind", kind },
+                    { "id", resource.ID },
+                    { "label", resource.Label },
+                    { "path", resource.AbsolutePath }
+                });
+            }
+        }
+
+        private Dictionary<string, object> GetComponentTypes()
+        {
+            var types = typeof(Component).Assembly.GetTypes()
+                .Where(t => t != typeof(Component) && !t.IsAbstract && typeof(Component).IsAssignableFrom(t))
+                .OrderBy(t => t.Name)
+                .Select(t => t.Name)
+                .ToArray();
+
+            return new Dictionary<string, object>
+            {
+                { "componentTypes", types }
+            };
+        }
+
+        private string ReadProjectVersion(string path)
+        {
+            if (CsFile.IsCS1(path)) return "1.01";
+
+            var doc = new XmlDocument();
+            doc.Load(path);
+            var root = (XmlElement)doc.SelectSingleNode(VersionInfo.AppName.Replace(" ", ""));
+            if (root == null) return null;
+            return root.GetAttribute("version");
+        }
+
+        private static string ResolvePath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path)) throw new ArgumentException("path is required.");
+            return Path.GetFullPath(Environment.ExpandEnvironmentVariables(path));
+        }
+
+        private static string ResolveOutputPath(string projectPath, string outputPath)
+        {
+            if (string.IsNullOrWhiteSpace(outputPath))
+            {
+                return Path.ChangeExtension(projectPath, ".bg");
+            }
+
+            return Path.GetFullPath(Environment.ExpandEnvironmentVariables(outputPath));
+        }
+
+        private static string GetRequiredPath(Dictionary<string, object> arguments)
+        {
+            string path = McpProtocol.GetString(arguments, "path");
+            if (string.IsNullOrWhiteSpace(path)) throw new ArgumentException("path is required.");
+            return path;
+        }
+
+        private string ToJson(object value)
+        {
+            return json.Serialize(value);
+        }
+
+        private static Dictionary<string, object> TextResult(string text)
+        {
+            return new Dictionary<string, object>
+            {
+                { "content", new object[]
+                    {
+                        new Dictionary<string, object>
+                        {
+                            { "type", "text" },
+                            { "text", text }
+                        }
+                    }
+                }
+            };
+        }
+
+        private static Dictionary<string, object> ErrorResult(string text)
+        {
+            var result = TextResult(text);
+            result["isError"] = true;
+            return result;
+        }
+
+        private static Dictionary<string, object> Tool(string name, string description, Dictionary<string, object> properties, string[] required)
+        {
+            return Tool(name, description, properties, required, null);
+        }
+
+        private static Dictionary<string, object> Tool(string name, string description, Dictionary<string, object> properties, string[] required, Dictionary<string, object> annotations)
+        {
+            var tool = new Dictionary<string, object>
+            {
+                { "name", name },
+                { "description", description },
+                { "inputSchema", new Dictionary<string, object>
+                    {
+                        { "type", "object" },
+                        { "properties", properties },
+                        { "required", required },
+                        { "additionalProperties", false }
+                    }
+                }
+            };
+
+            if (annotations != null) tool["annotations"] = annotations;
+            return tool;
+        }
+
+        private static Dictionary<string, object> StringProperty(string description)
+        {
+            return new Dictionary<string, object>
+            {
+                { "type", "string" },
+                { "description", description }
+            };
+        }
+
+        private sealed class LoadedProject
+        {
+            public string Path { get; set; }
+            public CsFile Project { get; set; }
+            public string Version { get; set; }
+            public bool IsLegacyCs1 { get; set; }
+        }
+    }
+}

--- a/CrazyStorm.McpServer/McpProtocol.cs
+++ b/CrazyStorm.McpServer/McpProtocol.cs
@@ -1,0 +1,165 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) StarX 2026
+ */
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Web.Script.Serialization;
+
+namespace CrazyStorm.McpServer
+{
+    internal sealed class McpProtocol
+    {
+        private const string ServerName = "crazystorm-mcp";
+        private const string ServerVersion = "0.1.0";
+        private const string DefaultProtocolVersion = "2025-06-18";
+
+        private readonly CrazyStormTools tools;
+        private readonly JavaScriptSerializer json = new JavaScriptSerializer();
+
+        public McpProtocol(CrazyStormTools tools)
+        {
+            this.tools = tools;
+        }
+
+        public void Run(TextReader input, TextWriter output, TextWriter error)
+        {
+            string line;
+            while ((line = input.ReadLine()) != null)
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+
+                try
+                {
+                    var request = json.DeserializeObject(line) as Dictionary<string, object>;
+                    if (request == null) continue;
+
+                    object id;
+                    bool hasId = request.TryGetValue("id", out id);
+                    string method = GetString(request, "method");
+                    if (string.IsNullOrEmpty(method)) continue;
+                    if (!hasId || method.StartsWith("notifications/", StringComparison.Ordinal)) continue;
+
+                    WriteJson(output, HandleRequest(id, method, GetMap(request, "params")));
+                }
+                catch (Exception ex)
+                {
+                    error.WriteLine(ex);
+                    WriteJson(output, CreateError(null, -32700, "Parse error", ex.Message));
+                }
+            }
+        }
+
+        private Dictionary<string, object> HandleRequest(object id, string method, Dictionary<string, object> parameters)
+        {
+            switch (method)
+            {
+                case "initialize":
+                    return CreateResult(id, new Dictionary<string, object>
+                    {
+                        { "protocolVersion", ChooseProtocolVersion(parameters) },
+                        { "capabilities", new Dictionary<string, object>
+                            {
+                                { "tools", new Dictionary<string, object>() }
+                            }
+                        },
+                        { "serverInfo", new Dictionary<string, object>
+                            {
+                                { "name", ServerName },
+                                { "version", ServerVersion }
+                            }
+                        }
+                    });
+
+                case "ping":
+                    return CreateResult(id, new Dictionary<string, object>());
+
+                case "tools/list":
+                    return CreateResult(id, new Dictionary<string, object>
+                    {
+                        { "tools", tools.ListTools() }
+                    });
+
+                case "tools/call":
+                    return CreateResult(id, tools.Call(GetString(parameters, "name"), GetMap(parameters, "arguments")));
+
+                default:
+                    return CreateError(id, -32601, "Method not found", method);
+            }
+        }
+
+        private string ChooseProtocolVersion(Dictionary<string, object> parameters)
+        {
+            string requested = GetString(parameters, "protocolVersion");
+            if (string.IsNullOrEmpty(requested)) return DefaultProtocolVersion;
+            return requested;
+        }
+
+        private void WriteJson(TextWriter output, object value)
+        {
+            output.WriteLine(json.Serialize(value));
+            output.Flush();
+        }
+
+        private static Dictionary<string, object> CreateResult(object id, object result)
+        {
+            return new Dictionary<string, object>
+            {
+                { "jsonrpc", "2.0" },
+                { "id", id },
+                { "result", result }
+            };
+        }
+
+        private static Dictionary<string, object> CreateError(object id, int code, string message, object data)
+        {
+            var error = new Dictionary<string, object>
+            {
+                { "code", code },
+                { "message", message }
+            };
+            if (data != null) error["data"] = data;
+
+            return new Dictionary<string, object>
+            {
+                { "jsonrpc", "2.0" },
+                { "id", id },
+                { "error", error }
+            };
+        }
+
+        internal static string GetString(Dictionary<string, object> source, string name)
+        {
+            if (source == null) return null;
+
+            object value;
+            if (!source.TryGetValue(name, out value) || value == null) return null;
+            return value as string ?? Convert.ToString(value);
+        }
+
+        internal static bool GetBool(Dictionary<string, object> source, string name, bool defaultValue)
+        {
+            if (source == null) return defaultValue;
+
+            object value;
+            if (!source.TryGetValue(name, out value) || value == null) return defaultValue;
+            if (value is bool) return (bool)value;
+
+            bool parsed;
+            if (bool.TryParse(Convert.ToString(value), out parsed)) return parsed;
+            return defaultValue;
+        }
+
+        internal static Dictionary<string, object> GetMap(Dictionary<string, object> source, string name)
+        {
+            if (source == null) return new Dictionary<string, object>();
+
+            object value;
+            if (!source.TryGetValue(name, out value) || value == null) return new Dictionary<string, object>();
+
+            var map = value as Dictionary<string, object>;
+            return map ?? new Dictionary<string, object>();
+        }
+    }
+}

--- a/CrazyStorm.McpServer/Program.cs
+++ b/CrazyStorm.McpServer/Program.cs
@@ -1,0 +1,30 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) StarX 2026
+ */
+using System;
+using System.IO;
+using System.Text;
+
+namespace CrazyStorm.McpServer
+{
+    internal static class Program
+    {
+        private static int Main(string[] args)
+        {
+            Console.InputEncoding = Encoding.UTF8;
+            Console.OutputEncoding = Encoding.UTF8;
+
+            try
+            {
+                new McpProtocol(new CrazyStormTools()).Run(Console.In, Console.Out, Console.Error);
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex);
+                return 1;
+            }
+        }
+    }
+}

--- a/CrazyStorm.McpServer/Properties/AssemblyInfo.cs
+++ b/CrazyStorm.McpServer/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) StarX 2026
+ */
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("CrazyStorm.McpServer")]
+[assembly: AssemblyDescription("Model Context Protocol server for CrazyStorm project files.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CrazyStorm.McpServer")]
+[assembly: AssemblyCopyright("Copyright (c) StarX 2026")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: ComVisible(false)]
+[assembly: Guid("FF7D097E-C0BF-40A8-B6DD-DA2DE3FDE731")]
+[assembly: AssemblyVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]

--- a/CrazyStorm.McpServer/README.md
+++ b/CrazyStorm.McpServer/README.md
@@ -1,0 +1,32 @@
+# CrazyStorm MCP Server
+
+This project exposes CrazyStorm project-file utilities through the Model Context Protocol over stdio.
+
+## Build
+
+Build the solution or just this project:
+
+```powershell
+dotnet msbuild .\CrazyStorm.McpServer\CrazyStorm.McpServer.csproj /p:Configuration=Debug /p:Platform=AnyCPU
+```
+
+## Client configuration
+
+Use the built executable as a stdio MCP server:
+
+```json
+{
+  "mcpServers": {
+    "crazystorm": {
+      "command": "D:\\Csharp\\crazystorm\\CrazyStorm2.0\\CrazyStorm.McpServer\\bin\\Debug\\CrazyStorm.McpServer.exe"
+    }
+  }
+}
+```
+
+## Tools
+
+- `crazy_storm_project_summary`: loads a `.bgp` or legacy `.mbg` project and returns project counts plus invalid resources.
+- `crazy_storm_validate_project`: validates loadability and can compile play data in memory with `compile=true`.
+- `crazy_storm_export_play_data`: exports playable `.bg` data. Existing output files require `overwrite=true`.
+- `crazy_storm_component_types`: lists component types available from `CrazyStorm.Core`.

--- a/CrazyStorm.McpServer/app.config
+++ b/CrazyStorm.McpServer/app.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+  </startup>
+</configuration>

--- a/CrazyStorm2.0.sln
+++ b/CrazyStorm2.0.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "Core\Core.csproj", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrazyStorm Player", "CrazyStorm Player\CrazyStorm Player\CrazyStorm Player.csproj", "{6969210A-FB47-48A8-B14C-52D4F0955E63}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrazyStorm.McpServer", "CrazyStorm.McpServer\CrazyStorm.McpServer.csproj", "{914017D4-B5F4-45AA-BC74-FEA7FD754F34}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,18 @@ Global
 		{6969210A-FB47-48A8-B14C-52D4F0955E63}.Release|Win32.Build.0 = Release|x86
 		{6969210A-FB47-48A8-B14C-52D4F0955E63}.Release|x86.ActiveCfg = Release|x86
 		{6969210A-FB47-48A8-B14C-52D4F0955E63}.Release|x86.Build.0 = Release|x86
+		{914017D4-B5F4-45AA-BC74-FEA7FD754F34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{914017D4-B5F4-45AA-BC74-FEA7FD754F34}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{914017D4-B5F4-45AA-BC74-FEA7FD754F34}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{914017D4-B5F4-45AA-BC74-FEA7FD754F34}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{914017D4-B5F4-45AA-BC74-FEA7FD754F34}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{914017D4-B5F4-45AA-BC74-FEA7FD754F34}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{914017D4-B5F4-45AA-BC74-FEA7FD754F34}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{914017D4-B5F4-45AA-BC74-FEA7FD754F34}.Release|Any CPU.Build.0 = Release|Any CPU
+		{914017D4-B5F4-45AA-BC74-FEA7FD754F34}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{914017D4-B5F4-45AA-BC74-FEA7FD754F34}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{914017D4-B5F4-45AA-BC74-FEA7FD754F34}.Release|Win32.ActiveCfg = Release|Any CPU
+		{914017D4-B5F4-45AA-BC74-FEA7FD754F34}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds a lightweight stdio MCP server for CrazyStorm project utilities.\n\nTools included:\n- crazy_storm_project_summary\n- crazy_storm_validate_project\n- crazy_storm_export_play_data\n- crazy_storm_component_types\n\nValidation performed:\n- dotnet msbuild .\\CrazyStorm.McpServer\\CrazyStorm.McpServer.csproj /p:Configuration=Debug /p:Platform=AnyCPU\n- MCP initialize/tools smoke tests\n- Temporary .bgp summary and .bg export smoke tests